### PR TITLE
Fix closing equipment crash

### DIFF
--- a/equipment.py
+++ b/equipment.py
@@ -24,12 +24,12 @@ class Equipment:
     def equipment_change_visibility(self, player):
         if self.visible:
             self.gui.hide()
-            self.master.properties()
+            self.master.change_mouse_visibility()
             self.master.taskMgr.add(player.camera_control, "Camera Control")
             self.visible = False
         else:
             self.gui.items = self.items
             self.gui.show()
-            self.master.properties_with_mouse()
+            self.master.change_mouse_visibility()
             self.master.taskMgr.remove("Camera Control")
             self.visible = True

--- a/player.py
+++ b/player.py
@@ -25,7 +25,7 @@ class Player(DirectObject):
 
         self.camera_model = self.master.loader.loadModel("mesh/models/person/person")
         self.camera_model.reparentTo(self.master.render)
-        self.camera_model.setPos(0, 15, 200)
+        self.camera_model.setPos(0, 15, 300)
 
         self.master.camera.reparentTo(self.camera_model)
         self.master.camera.setY(self.master.camera, -5)

--- a/window.py
+++ b/window.py
@@ -55,8 +55,10 @@ class Window:
                 # taskMgr.doMethodLater(.1, self.traverse_task, "tsk_traverse")
 
         def properties(self):
-            self.makeDefaultPipe()
-            props = WindowProperties().getDefault()
+            if not self.pipe:
+                self.makeDefaultPipe()
+
+            props = WindowProperties()
 
             props.setTitle("Title placeholder")
 
@@ -68,19 +70,19 @@ class Window:
             else:
                 props.setSize(self.option[Options.RES.value][Options.X.value],
                               self.option[Options.RES.value][Options.Y.value])
+
             props.setCursorHidden(True)
+            props.setDefault(props)
 
             self.openMainWindow(props)
 
-        def properties_with_mouse(self):
-            props = WindowProperties()
-            if self.option[Options.FULL.value]:
-                props.setSize(self.option[Options.RES.value][Options.X.value],
-                              self.option[Options.RES.value][Options.Y.value])
+        def change_mouse_visibility(self):
+            props = WindowProperties().getDefault()
+            if props.getCursorHidden():
+                props.setCursorHidden(False)
             else:
-                props.setSize(self.option[Options.RES.value][Options.X.value] - 100,
-                              self.option[Options.RES.value][Options.Y.value] - 100)
-            props.setCursorHidden(False)
+                props.setCursorHidden(True)
+            props.setDefault(props)
             self.win.requestProperties(props)
 
         def traverse_task(self, task=None):


### PR DESCRIPTION
Closes #4 
Refactored window.py for using same WindowProperties insted of making new every time opening/closing equipment.
Starting position of player changed.